### PR TITLE
disable Internal Model Validator

### DIFF
--- a/SampleWebApiAspNetCore/Startup.cs
+++ b/SampleWebApiAspNetCore/Startup.cs
@@ -54,7 +54,8 @@ namespace WebApplication11
                 var actionContext = implementationFactory.GetService<IActionContextAccessor>().ActionContext;
                 return new UrlHelper(actionContext);
             });
-
+            // https://github.com/aspnet/AspNetCore/issues/3485
+            services.Configure<ApiBehaviorOptions>(opt =>{opt.SuppressModelStateInvalidFilter = true;});
             services.AddMvcCore().AddVersionedApiExplorer(o => o.GroupNameFormat = "'v'VVV");
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
             services.AddApiVersioning(config =>


### PR DESCRIPTION
In ASP.NET Core 2.1 controllers, an internal Model Validator is implemented by default thus your custom validator would not work.

For more information visit        
https://github.com/aspnet/AspNetCore/issues/3485  
https://stackoverflow.com/questions/51125569/net-core-2-1-override-automatic-model-validation